### PR TITLE
fix: Correct directory comparison in build_spec function

### DIFF
--- a/lua/neotest-swift-testing/init.lua
+++ b/lua/neotest-swift-testing/init.lua
@@ -157,7 +157,7 @@ local function build_spec(args)
     if namespace ~= nil and test ~= nil then
       table.insert(filters, namespace .. "." .. test)
     end
-  elseif position.type == "dir" and position.name ~= cwd then
+  elseif position.type == "dir" and position.path ~= cwd then
     table.insert(filters, position.name)
   end
 


### PR DESCRIPTION
The `build_spec` function was incorrectly comparing `position.name` to `cwd` when determining directory filters. This has been updated to compare `position.path` to `cwd` instead, ensuring accurate filtering logic.